### PR TITLE
Fix bug that can't receive StatusChanged callback when a client was disconnected

### DIFF
--- a/HasteClientLib/NetworkConnection.cs
+++ b/HasteClientLib/NetworkConnection.cs
@@ -213,6 +213,11 @@ namespace Haste
 
         void IListener.OnStatusChanged(StatusCode statusCode, string message)
         {
+            if (StatusChanged != null)
+            {
+                StatusChanged(statusCode, message);
+            }
+
             switch (statusCode)
             {
                 case StatusCode.ServerConnected:
@@ -225,11 +230,6 @@ namespace Haste
                 case StatusCode.FailedToSend:
                     Disconnect();
                     break;
-            }
-
-            if (StatusChanged != null)
-            {
-                StatusChanged(statusCode, message);
             }
         }
 


### PR DESCRIPTION
Motivation:

A user can't receive StatusChanged callback when i failed to send a data, just a client was disconnected.

Modification:

Before Haste handle a event, should propagate a event to listener.

Result:

A user can receive StatusChanged callback when i failed to send a data.

Fixes #4 .