### PR TITLE
Improve RTO like TCP-Backoff

### DIFF
--- a/HasteClientLib/Network/RoundTripTime.cs
+++ b/HasteClientLib/Network/RoundTripTime.cs
@@ -24,6 +24,8 @@ namespace Haste.Network
         internal const int InitialMeanOfRoundTripTime = 1000;
         internal const int InitialMeanOfRoundTripTimeVariance = 20;
 
+        private static readonly uint[] BackOffMultiple = { 1, 1, 2, 4, 8, 16 };
+
         protected int _meanOfRoundTripTime;
         protected int _meanOfRoundTripTimeVariance = 1;
 
@@ -91,6 +93,13 @@ namespace Haste.Network
             {
                 Interlocked.Exchange(ref _highestRoundTripTimeVariance, newRttVar);
             }
+        }
+
+        internal static uint GetBackOffMultiple(uint sentAttempts)
+        {
+            if (sentAttempts >= BackOffMultiple.Length)
+                return BackOffMultiple[BackOffMultiple.Length - 1];
+            return BackOffMultiple[sentAttempts];
         }
     }
 }

--- a/HasteClientLib/Network/UDP/UdpPeer.Send.cs
+++ b/HasteClientLib/Network/UDP/UdpPeer.Send.cs
@@ -214,7 +214,7 @@ namespace Haste.Network
 
                     if (command.IsTimeout(currentTime, SentCountAllowance))
                     {
-                        Log(LogLevel.Info, "Timeout-disconnect [{0}:{1}]", RemoteEndPoint.Address, RemoteEndPoint.Port);
+                        Log(LogLevel.Error, "Timeout-disconnect [{0}:{1}]", RemoteEndPoint.Address, RemoteEndPoint.Port);
                         Disconnect(DisconnectReason.Timeout, false);
                         return false;
                     }

--- a/HasteClientLib/Queues/ReliableSendQueue.cs
+++ b/HasteClientLib/Queues/ReliableSendQueue.cs
@@ -48,7 +48,7 @@ namespace Haste.Network.Queues
             command.SentTime = currentSendingTime;
             command.SendAttempts++; // 송신 횟수
             // 재전송을 위한 평균 RTT + 평균 분산 값
-            command.RoundTripTimeout = newRtt * command.SendAttempts;
+            command.RoundTripTimeout = newRtt * command.SendAttempts * RoundTripTime.GetBackOffMultiple(command.SendAttempts);
 
             lock (_sentCommands)
             {

--- a/HasteClientLibTest/HasteClientLib.Test.csproj
+++ b/HasteClientLibTest/HasteClientLib.Test.csproj
@@ -77,6 +77,7 @@
     <Compile Include="ByteBuffer\ByteBufferUtilTest.cs" />
     <Compile Include="ByteBuffer\ByteReadTest.cs" />
     <Compile Include="ByteBuffer\ReadWriteTest.cs" />
+    <Compile Include="Network\RoundTripTimeTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Security\BigIntegerTest.cs" />
     <Compile Include="Security\DiffieHellmanTest.cs" />

--- a/HasteClientLibTest/Network/RoundTripTimeTest.cs
+++ b/HasteClientLibTest/Network/RoundTripTimeTest.cs
@@ -1,0 +1,37 @@
+﻿/*
+* Copyright 2016 NHN Entertainment Corp.
+*
+* NHN Entertainment Corp. licenses this file to you under the Apache License,
+* version 2.0 (the "License"); you may not use this file except in compliance
+* with the License. You may obtain a copy of the License at:
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using Haste.Network;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace HasteClientLibTest.Network
+{
+    [TestClass]
+    public class RoundTripTimeTest
+    {
+        [TestMethod]
+        public void BackOffMultipleTest()
+        {
+            uint[] expectedBackOffMultiple = { 1, 1, 2, 4, 8, 16 };
+            for (uint i = 0; i < 10; i++)
+            {
+                var backOff = RoundTripTime.GetBackOffMultiple(i);
+                uint index = (i >= expectedBackOffMultiple.Length) ? (uint)(expectedBackOffMultiple.Length - 1) : i;
+                Assert.AreEqual(expectedBackOffMultiple[index], backOff);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

A user can't continue a connection when increased RTT suddenly.

Modification:

RTO increases like TCP-backoff.

Result:

It will be reduced a situation that a user was disconnected.

Fixes #7 
